### PR TITLE
Fix v4 theme contrast + restore modern landing (green direction)

### DIFF
--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -1,16 +1,32 @@
 <div class="row flex-xl-nowrap">
     <main class="col-12 col-md-12 col-xl-12 pl-md-12" role="main">
-        <div class="bg-light p-5 rounded jumbotron">
-            <img src="images/doctoolchain-logo-blue.png" alt="docToolchain" style="float: left" />
-            <h1>docToolchain <span class="badge bg-primary">v4</span></h1>
-            <p class="lead">
-                Docs-as-code. Fast. No build tool at runtime.
-            </p>
-            <p>docToolchain v4 runs directly on the JVM &mdash; no Gradle, no daemon, startup in 2&ndash;3 seconds.
-                One wrapper script, one config file, powerful output.
-            </p>
-            <a class="btn btn-primary btn-lg" href="010_manual/20_install.html" role="button">Get Started</a>
+        <section class="dtc-hero">
+            <span class="dtc-bp-corner tl"></span><span class="dtc-bp-corner tr"></span>
+            <span class="dtc-bp-corner bl"></span><span class="dtc-bp-corner br"></span>
+            <span class="dtc-bp-dim">— docs-as-code —</span>
+            <img src="images/doctoolchain-logo-blue.png" alt="docToolchain" class="dtc-hero-logo" />
+            <span class="dtc-tag">§ DOCTOOLCHAIN v4</span>
+            <h1>docToolchain <span class="grad">v4</span></h1>
+            <p class="lead">Docs-as-code. Fast. No build tool at runtime.</p>
+            <p class="dtc-hero-intro">docToolchain v4 runs directly on the JVM &mdash; no Gradle, no daemon, startup in 2&ndash;3 seconds. One wrapper script, one config file, powerful output.</p>
+            <div class="dtc-cta">
+                <a class="dtc-btn dtc-btn-primary" href="010_manual/20_install.html">🚀 Get Started</a>
+                <a class="dtc-btn dtc-btn-ghost" href="https://github.com/docToolchain/docToolchain" target="_blank" rel="noopener">★ GitHub</a>
+            </div>
+        </section>
+
+        <div class="dtc-divider"><span class="seg"></span><span class="lk">⛓</span><span class="lk">⛓</span><span class="lk">⛓</span><span class="seg"></span></div>
+
+        <div class="dtc-sec-head">
+            <h2>One toolchain, from keystroke to publish</h2>
+            <p>docToolchain wires the best open-source tools into a single, reproducible flow.</p>
         </div>
+        <section class="dtc-pipeline">
+            <div class="dtc-link"><div class="node on">📝</div><b>Write</b><span>asciidoc</span></div>
+            <div class="dtc-link"><div class="node">🎨</div><b>Render</b><span>asciidoctor</span></div>
+            <div class="dtc-link"><div class="node">📐</div><b>Diagram</b><span>plantuml</span></div>
+            <div class="dtc-link"><div class="node">🚀</div><b>Publish</b><span>confluence</span></div>
+        </section>
 
         <div class="row row-cols-1 row-cols-md-3 mb-3 text-center mt-4">
             <div class="col">

--- a/src/site/assets/css/doctoolchain-v4.css
+++ b/src/site/assets/css/doctoolchain-v4.css
@@ -1,44 +1,49 @@
 /* =====================================================================
-   docToolchain v4 — theme overlay
-   Loaded AFTER the legacy Docsy/Bootstrap theme so it can override it.
-   Design language: blueprint surface · docs-as-code · the toolchain.
+   docToolchain v4 — theme overlay (green / emerald direction)
+   Loaded AFTER theme-v4.css so it extends it (structure + full dark mode).
+   Palette harmonises with theme-v4.css: emerald #059669 family.
    ===================================================================== */
 
 :root {
-  --dtc-blue-900:#10294f;
-  --dtc-blue-700:#1e53a0;
-  --dtc-blue-500:#3772ff;
-  --dtc-teal-500:#1aa890;
-  --dtc-teal-300:#5fd0c0;
-  --dtc-teal-100:#d3f3ee;
-  --dtc-coral:#ed6a5a;
-  --dtc-orange:#ffa630;
+  --g-900:#064e3b;
+  --g-800:#065f46;
+  --g-700:#047857;
+  --g-600:#059669;
+  --g-500:#10b981;
+  --g-300:#6ee7b7;
+  --g-100:#d1fae5;
+  --g-50:#ecfdf5;
+  --teal:#0d9488;
+  --cyan:#0e7490;
 
-  --dtc-ink:#10141c;
-  --dtc-muted:#5b6677;
+  --dtc-ink:#10241c;
+  --dtc-muted:#4b6358;
   --dtc-bg:#ffffff;
-  --dtc-bg-soft:#f5f8fc;
+  --dtc-bg-soft:#f3faf6;
   --dtc-card:#ffffff;
-  --dtc-border:#e4ebf3;
-  --dtc-code-bg:#0d1830;
-  --dtc-grid:rgba(55,114,255,.07);
+  --dtc-border:#dcebe3;
+  --dtc-code-bg:#0b2a20;
+  --dtc-code-ink:#d6f5e8;
+  --dtc-grid:rgba(5,150,105,.06);
 
-  --dtc-shadow:0 14px 40px -18px rgba(16,41,79,.28);
+  --dtc-shadow:0 14px 40px -18px rgba(6,78,59,.28);
   --dtc-radius:14px;
-  --dtc-grad:linear-gradient(120deg,var(--dtc-blue-700),var(--dtc-blue-500) 55%,var(--dtc-teal-300));
+  --dtc-grad:linear-gradient(120deg,var(--g-700),var(--g-600) 55%,var(--g-500));
 
   --dtc-font:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   --dtc-mono:'JetBrains Mono',ui-monospace,'SF Mono',Menlo,Consolas,monospace;
 }
 
 [data-theme="dark"] {
-  --dtc-ink:#eaf1fb;
-  --dtc-muted:#9fb0c7;
-  --dtc-bg:#0a1120;
-  --dtc-bg-soft:#0f1a2e;
-  --dtc-card:#111c30;
-  --dtc-border:#1e2c44;
-  --dtc-grid:rgba(95,208,192,.08);
+  --dtc-ink:#e6f2ec;
+  --dtc-muted:#9fbcae;
+  --dtc-bg:#0b1411;
+  --dtc-bg-soft:#0f1c17;
+  --dtc-card:#13241d;
+  --dtc-border:#21392f;
+  --dtc-code-bg:#08120e;
+  --dtc-code-ink:#d6f5e8;
+  --dtc-grid:rgba(16,185,129,.07);
   --dtc-shadow:0 14px 40px -18px rgba(0,0,0,.7);
 }
 
@@ -50,346 +55,232 @@ body {
   -webkit-font-smoothing:antialiased;
   transition:background .25s ease, color .25s ease;
 }
-.td-main, .td-content, main[role="main"] { background:transparent; }
-
-/* blueprint surface behind the whole page */
 body::before {
   content:"";
   position:fixed; inset:0; z-index:-1; pointer-events:none;
   background:
-    linear-gradient(var(--dtc-grid) 1px, transparent 1px) 0 0 / 28px 28px,
-    linear-gradient(90deg, var(--dtc-grid) 1px, transparent 1px) 0 0 / 28px 28px;
+    linear-gradient(var(--dtc-grid) 1px, transparent 1px) 0 0 / 30px 30px,
+    linear-gradient(90deg, var(--dtc-grid) 1px, transparent 1px) 0 0 / 30px 30px;
 }
 
-/* ---- navbar -------------------------------------------------------- */
-.td-navbar {
-  background:color-mix(in srgb, var(--dtc-bg) 84%, transparent) !important;
-  backdrop-filter:saturate(180%) blur(14px);
-  border-bottom:1px solid var(--dtc-border);
-  box-shadow:none !important;
-}
+/* ---- navbar (dark emerald in both schemes) ------------------------- */
+.td-navbar { background:var(--g-900) !important; box-shadow:none !important; }
 .td-navbar .navbar-brand,
-.td-navbar .nav-link { color:var(--dtc-ink) !important; }
-.td-navbar .nav-link { font-weight:500; opacity:.8; }
+.td-navbar .nav-link { color:#eafaf3 !important; }
+.td-navbar .nav-link { font-weight:500; opacity:.85; }
 .td-navbar .nav-link:hover,
 .td-navbar .nav-link.active { opacity:1; }
-.td-navbar .navbar-brand { font-weight:800; letter-spacing:-.02em; }
-
 .td-search-input {
-  background:var(--dtc-bg-soft);
-  border:1px solid var(--dtc-border);
-  border-radius:10px;
-  color:var(--dtc-ink);
+  background:rgba(255,255,255,.12); border:1px solid rgba(255,255,255,.18);
+  border-radius:10px; color:#fff;
 }
-.td-search-input::placeholder { color:var(--dtc-muted); }
+.td-search-input::placeholder { color:rgba(255,255,255,.7); }
 
-/* theme toggle button (injected in menu.gsp) */
+/* colour-scheme toggle button (menu.gsp) */
 .dtc-theme-toggle {
   width:38px; height:38px; flex:0 0 auto;
-  border-radius:10px;
-  border:1px solid var(--dtc-border);
-  background:var(--dtc-card);
-  color:var(--dtc-ink);
+  border-radius:10px; border:1px solid rgba(255,255,255,.25);
+  background:rgba(255,255,255,.1); color:#fff;
   cursor:pointer; font-size:16px; line-height:1;
-  display:inline-grid; place-items:center;
-  margin-left:.75rem;
-  transition:border-color .2s, transform .15s;
+  display:inline-grid; place-items:center; margin-left:.75rem;
+  transition:background .2s, transform .15s;
 }
-.dtc-theme-toggle:hover { border-color:var(--dtc-blue-500); transform:translateY(-1px); }
+.dtc-theme-toggle:hover { background:rgba(255,255,255,.2); transform:translateY(-1px); }
 
-/* ---- sidebar (left nav) ------------------------------------------- */
+/* ---- links --------------------------------------------------------- */
+.td-content a:not(.btn):not(.dtc-btn) { color:var(--g-600); }
+[data-theme="dark"] .td-content a:not(.btn):not(.dtc-btn) { color:var(--g-300); }
+
+/* ---- sidebar ------------------------------------------------------- */
 .td-sidebar { border-right:1px solid var(--dtc-border); }
-.td-sidebar-link__section,
-.td-sidebar-nav a.td-sidebar-link {
-  color:var(--dtc-muted); border-radius:9px; font-weight:500;
-}
-.td-sidebar-nav a.td-sidebar-link:hover {
-  color:var(--dtc-ink); background:var(--dtc-bg-soft); text-decoration:none;
-}
-/* C·2 blueprint-bracket active state — no pastel fill bar */
+.td-sidebar-nav a.td-sidebar-link { color:var(--dtc-muted); border-radius:9px; font-weight:500; }
+.td-sidebar-nav a.td-sidebar-link:hover { color:var(--dtc-ink); background:var(--dtc-bg-soft); text-decoration:none; }
 .td-sidebar-nav a.td-sidebar-link.active,
-.td-sidebar-link__section.active {
-  color:var(--dtc-blue-700) !important;
-  font-weight:700;
-  position:relative;
-}
-[data-theme="dark"] .td-sidebar-nav a.td-sidebar-link.active { color:var(--dtc-teal-300) !important; }
-.td-sidebar-nav a.td-sidebar-link.active::before {
-  content:"["; font-family:var(--dtc-mono); color:var(--dtc-blue-500);
-  margin-right:3px; font-weight:700;
-}
-.td-sidebar-nav a.td-sidebar-link.active::after {
-  content:"]"; font-family:var(--dtc-mono); color:var(--dtc-blue-500);
-  margin-left:3px; font-weight:700;
-}
-
-/* sidebar disclosure arrows */
+.td-sidebar-link__section.active { color:var(--g-700) !important; font-weight:700; position:relative; }
+[data-theme="dark"] .td-sidebar-nav a.td-sidebar-link.active,
+[data-theme="dark"] .td-sidebar-link__section.active { color:var(--g-300) !important; }
+.td-sidebar-nav a.td-sidebar-link.active::before { content:"["; font-family:var(--dtc-mono); color:var(--g-500); margin-right:3px; font-weight:700; }
+.td-sidebar-nav a.td-sidebar-link.active::after  { content:"]"; font-family:var(--dtc-mono); color:var(--g-500); margin-left:3px;  font-weight:700; }
 summary { color:var(--dtc-ink); }
 
+/* arc42 chapter numbering */
+.arc42-num { font-family:var(--dtc-mono); font-weight:700; font-size:.78em; color:var(--g-600); margin-right:6px; opacity:.9; letter-spacing:.02em; }
+[data-theme="dark"] .arc42-num { color:var(--g-300); }
+
 /* =====================================================================
-   AsciiDoc headings — colour-differentiated per level
-   Scope to generated content so we don't touch chrome.
+   AsciiDoc headings — colour-differentiated (cool green/teal family)
    ===================================================================== */
-.td-content h1,
-.td-content h2,
-.td-content h3,
-.td-content h4,
-.td-content h5,
-.td-content h6 {
-  font-family:var(--dtc-font);
-  letter-spacing:-.02em;
-  scroll-margin-top:5rem;
+.td-content h1, .td-content h2, .td-content h3,
+.td-content h4, .td-content h5, .td-content h6 {
+  font-family:var(--dtc-font); letter-spacing:-.02em; scroll-margin-top:5rem;
 }
-
-/* H1 — page title: deep blue, blueprint section tag feel */
-.td-content h1 {
-  color:var(--dtc-blue-900) !important;
-  font-weight:900;
-  border-bottom:0;
-}
-[data-theme="dark"] .td-content h1 { color:#eaf1fb !important; }
-
-/* H2 — primary brand blue, with a monospace section tick */
-.td-content h2 {
-  color:var(--dtc-blue-700) !important;
-  font-weight:800;
-  padding-top:.3em;
-  border-top:0;
-}
+.td-content h1 { color:var(--g-900) !important; font-weight:900; border-bottom:0; }
+.td-content h2 { color:var(--g-600) !important; font-weight:800; padding-top:.3em; border-top:0; }
+.td-content h2::before { content:"§ "; font-family:var(--dtc-mono); color:var(--g-500); font-weight:700; font-size:.7em; vertical-align:.15em; }
 .td-content .sect1 + .sect1 { border-top:1px dashed var(--dtc-border); }
-.td-content h2::before {
-  content:"§ ";
-  font-family:var(--dtc-mono);
-  color:var(--dtc-orange);
-  font-weight:700;
-  font-size:.7em;
-  vertical-align:.15em;
-}
-[data-theme="dark"] .td-content h2 { color:var(--dtc-teal-300) !important; }
-
-/* H3 — bright blue */
-.td-content h3 {
-  color:var(--dtc-blue-500) !important;
-  font-weight:700;
-}
-
-/* H4 — teal */
-.td-content h4 {
-  color:var(--dtc-teal-500) !important;
-  font-weight:700;
-}
-[data-theme="dark"] .td-content h4 { color:var(--dtc-teal-300) !important; }
-
-/* H5 / H6 — coral & muted, uppercase micro-headings */
-.td-content h5 {
-  color:var(--dtc-coral) !important;
-  font-weight:700;
-}
-.td-content h6 {
-  color:var(--dtc-muted) !important;
-  font-weight:700;
-  text-transform:uppercase;
-  letter-spacing:.06em;
-  font-size:.85em;
-}
-
-/* anchor link colour to match brand */
+.td-content h3 { color:var(--teal) !important; font-weight:700; }
+.td-content h4 { color:var(--cyan) !important; font-weight:700; }
+.td-content h5 { color:var(--g-700) !important; font-weight:700; }
+.td-content h6 { color:var(--dtc-muted) !important; font-weight:700; text-transform:uppercase; letter-spacing:.06em; font-size:.85em; }
 .td-content h1 > a.link, .td-content h2 > a.link, .td-content h3 > a.link,
-.td-content h4 > a.link, .td-content h5 > a.link, .td-content h6 > a.link {
-  color:inherit !important;
-}
+.td-content h4 > a.link, .td-content h5 > a.link, .td-content h6 > a.link { color:inherit !important; }
 
-/* body text & links */
+[data-theme="dark"] .td-content h1 { color:var(--g-300) !important; }
+[data-theme="dark"] .td-content h2 { color:#34d399 !important; }
+[data-theme="dark"] .td-content h3 { color:#2dd4bf !important; }
+[data-theme="dark"] .td-content h4 { color:#22d3ee !important; }
+[data-theme="dark"] .td-content h5 { color:#6ee7b7 !important; }
+
 .td-content p, .td-content li { color:var(--dtc-ink); }
-.td-content a:not(.btn) { color:var(--dtc-blue-500); }
 
 /* ---- code ---------------------------------------------------------- */
-.td-content pre,
-.td-content .listingblock pre {
-  background:var(--dtc-code-bg);
-  color:#cdd9f0;
-  border:1px solid #1b2c4d;
-  border-radius:var(--dtc-radius);
-  box-shadow:var(--dtc-shadow);
-  font-family:var(--dtc-mono);
-  font-size:.86em;
+.td-content pre, .td-content .listingblock pre {
+  background:var(--dtc-code-bg); color:var(--dtc-code-ink);
+  border:1px solid rgba(16,185,129,.25); border-radius:var(--dtc-radius);
+  box-shadow:var(--dtc-shadow); font-family:var(--dtc-mono); font-size:.86em;
 }
-.td-content code,
-.td-content :not(pre) > code {
-  font-family:var(--dtc-mono);
-  background:var(--dtc-bg-soft);
-  border:1px solid var(--dtc-border);
-  border-radius:6px;
-  padding:.12em .4em;
-  color:var(--dtc-blue-700);
+.td-content code, .td-content :not(pre) > code {
+  font-family:var(--dtc-mono); background:var(--dtc-bg-soft);
+  border:1px solid var(--dtc-border); border-radius:6px; padding:.12em .4em; color:var(--g-700);
 }
-[data-theme="dark"] .td-content :not(pre) > code { color:var(--dtc-teal-300); }
+[data-theme="dark"] .td-content :not(pre) > code { color:var(--g-300); }
 
 /* ---- admonitions --------------------------------------------------- */
 .td-content .admonitionblock > table {
-  background:var(--dtc-card);
-  border:1px solid var(--dtc-border);
-  border-left:4px solid var(--dtc-blue-500);
-  border-radius:var(--dtc-radius);
-  box-shadow:var(--dtc-shadow);
+  background:var(--dtc-card); border:1px solid var(--dtc-border);
+  border-left:4px solid var(--g-600); border-radius:var(--dtc-radius); box-shadow:var(--dtc-shadow);
 }
 .td-content .admonitionblock td.content { color:var(--dtc-muted); }
-.td-content .admonitionblock.tip > table     { border-left-color:var(--dtc-teal-300); }
-.td-content .admonitionblock.note > table    { border-left-color:var(--dtc-blue-500); }
-.td-content .admonitionblock.warning > table { border-left-color:var(--dtc-orange); }
+.td-content .admonitionblock.tip > table     { border-left-color:var(--g-500); }
+.td-content .admonitionblock.note > table    { border-left-color:var(--teal); }
+.td-content .admonitionblock.warning > table { border-left-color:#d97706; }
 .td-content .admonitionblock.caution > table,
-.td-content .admonitionblock.important > table { border-left-color:var(--dtc-coral); }
+.td-content .admonitionblock.important > table { border-left-color:#dc2626; }
 
 /* ---- tables -------------------------------------------------------- */
-.td-content table.tableblock {
-  border:1px solid var(--dtc-border);
-  border-radius:var(--dtc-radius);
-  overflow:hidden;
-}
-.td-content table.tableblock thead th {
-  background:var(--dtc-bg-soft);
-  color:var(--dtc-ink);
-}
+.td-content table.tableblock { border:1px solid var(--dtc-border); border-radius:var(--dtc-radius); overflow:hidden; }
+.td-content table.tableblock thead th { background:var(--dtc-bg-soft); color:var(--dtc-ink); }
 .td-content table.tableblock td { color:var(--dtc-muted); }
 
 /* ---- right column / TOC ------------------------------------------- */
 .td-toc { border-left:1px solid var(--dtc-border); }
 .td-page-meta a { color:var(--dtc-muted); }
-.td-page-meta a:hover { color:var(--dtc-blue-500); }
+.td-page-meta a:hover { color:var(--g-600); }
 
 /* ---- footer -------------------------------------------------------- */
-footer.bg-dark {
-  background:var(--dtc-blue-900) !important;
-  border-top:1px solid var(--dtc-border);
-}
-
-/* =====================================================================
-   arc42 chapter numbering (Element C) — top-level sidebar entries
-   ===================================================================== */
-.arc42-num {
-  font-family:var(--dtc-mono);
-  font-weight:700;
-  font-size:.78em;
-  color:var(--dtc-orange);
-  margin-right:6px;
-  opacity:.85;
-  letter-spacing:.02em;
-}
+footer.bg-dark { background:var(--g-900) !important; border-top:1px solid var(--dtc-border); }
 
 /* =====================================================================
    Landing page — blueprint hero · toolchain pipeline · feature grid
    ===================================================================== */
-.dtc-landing { max-width:1100px; margin:0 auto; padding:38px 24px 60px; }
+.dtc-landing { max-width:1100px; margin:0 auto; padding:30px 4px 50px; }
 
 .dtc-hero {
   position:relative;
   background:
     linear-gradient(var(--dtc-grid) 1px, transparent 1px) 0 0 / 26px 26px,
     linear-gradient(90deg, var(--dtc-grid) 1px, transparent 1px) 0 0 / 26px 26px,
-    var(--dtc-card);
-  border:1px solid var(--dtc-border);
-  border-radius:22px;
-  padding:60px 54px;
-  box-shadow:var(--dtc-shadow);
-  overflow:hidden;
+    linear-gradient(135deg, var(--g-50), var(--g-100));
+  border:1px solid var(--g-300);
+  border-radius:22px; padding:54px 48px; box-shadow:var(--dtc-shadow); overflow:hidden;
 }
-.dtc-hero::after {
-  content:""; position:absolute; inset:0; pointer-events:none;
+[data-theme="dark"] .dtc-hero {
   background:
-    radial-gradient(60% 60% at 85% -10%, rgba(95,208,192,.18), transparent 60%),
-    radial-gradient(50% 50% at 0% 0%, rgba(55,114,255,.14), transparent 60%);
+    linear-gradient(var(--dtc-grid) 1px, transparent 1px) 0 0 / 26px 26px,
+    linear-gradient(90deg, var(--dtc-grid) 1px, transparent 1px) 0 0 / 26px 26px,
+    linear-gradient(135deg, #0c241b, #0a1a14);
+  border-color:var(--dtc-border);
 }
 .dtc-hero > * { position:relative; z-index:1; }
-.dtc-bp-corner { position:absolute; width:16px; height:16px; border:2px solid var(--dtc-blue-500); z-index:1; }
+.dtc-bp-corner { position:absolute; width:16px; height:16px; border:2px solid var(--g-600); z-index:1; }
 .dtc-bp-corner.tl { top:14px; left:14px; border-right:0; border-bottom:0; }
 .dtc-bp-corner.tr { top:14px; right:14px; border-left:0; border-bottom:0; }
 .dtc-bp-corner.bl { bottom:14px; left:14px; border-right:0; border-top:0; }
 .dtc-bp-corner.br { bottom:14px; right:14px; border-left:0; border-top:0; }
-.dtc-bp-dim {
-  position:absolute; top:18px; left:50%; transform:translateX(-50%);
-  font-family:var(--dtc-mono); font-size:11px; color:var(--dtc-blue-500);
-  letter-spacing:.12em; z-index:1;
-}
-.dtc-tag {
-  display:inline-block; font-family:var(--dtc-mono); font-size:12px;
-  color:var(--dtc-blue-500); border:1px dashed var(--dtc-blue-500);
-  padding:3px 10px; border-radius:6px; margin-bottom:18px;
-}
-.dtc-hero h1 {
-  font-family:var(--dtc-font); font-size:clamp(34px,5vw,54px);
-  line-height:1.06; letter-spacing:-.03em; font-weight:900;
-  color:var(--dtc-ink); margin:0;
-}
-.dtc-hero .grad {
-  background:var(--dtc-grad); -webkit-background-clip:text;
-  background-clip:text; color:transparent;
-}
-.dtc-hero-logo { width:64px; height:auto; display:block; margin-bottom:16px; }
-.dtc-hero .lead {
-  font-size:19px; color:var(--dtc-muted); max-width:560px; margin:20px 0 16px;
-}
-.dtc-hero-intro { color:var(--dtc-muted); max-width:580px; margin:0 0 30px; }
+.dtc-bp-dim { position:absolute; top:18px; left:50%; transform:translateX(-50%); font-family:var(--dtc-mono); font-size:11px; color:var(--g-600); letter-spacing:.12em; z-index:1; }
+.dtc-hero-logo { width:60px; height:auto; display:block; margin-bottom:14px; }
+.dtc-tag { display:inline-block; font-family:var(--dtc-mono); font-size:12px; color:var(--g-700); border:1px dashed var(--g-600); padding:3px 10px; border-radius:6px; margin-bottom:16px; }
+[data-theme="dark"] .dtc-tag { color:var(--g-300); border-color:var(--g-500); }
+.dtc-hero h1 { font-family:var(--dtc-font); font-size:clamp(34px,5vw,52px); line-height:1.06; letter-spacing:-.03em; font-weight:900; color:var(--g-900); margin:0; }
+[data-theme="dark"] .dtc-hero h1 { color:#eafaf3; }
+.dtc-hero h1 .grad, .dtc-hero .grad { background:var(--dtc-grad); -webkit-background-clip:text; background-clip:text; color:transparent; }
+.dtc-hero .lead { font-size:19px; color:var(--g-800); max-width:620px; margin:18px 0 14px; font-weight:600; }
+[data-theme="dark"] .dtc-hero .lead { color:var(--g-300); }
+.dtc-hero-intro { color:var(--dtc-muted); max-width:620px; margin:0 0 28px; }
+[data-theme="dark"] .dtc-hero-intro { color:#bcd6ca; }
 .dtc-cta { display:flex; gap:14px; flex-wrap:wrap; }
-.dtc-btn {
-  display:inline-flex; align-items:center; gap:8px;
-  font-weight:600; font-size:15px; padding:13px 24px;
-  border-radius:12px; border:1px solid transparent; cursor:pointer;
-  text-decoration:none; transition:transform .15s, box-shadow .2s, border-color .2s;
-}
+.dtc-btn { display:inline-flex; align-items:center; gap:8px; font-weight:600; font-size:15px; padding:13px 24px; border-radius:12px; border:1px solid transparent; cursor:pointer; text-decoration:none; transition:transform .15s, box-shadow .2s, border-color .2s; }
 .dtc-btn:hover { transform:translateY(-2px); text-decoration:none; }
-.dtc-btn-primary { background:var(--dtc-grad); color:#fff; box-shadow:0 8px 20px -6px rgba(55,114,255,.55); }
-.dtc-btn-ghost { background:transparent; color:var(--dtc-ink); border-color:var(--dtc-border); }
-.dtc-btn-ghost:hover { border-color:var(--dtc-blue-500); }
+.dtc-btn-primary { background:var(--dtc-grad); color:#fff !important; box-shadow:0 8px 20px -6px rgba(5,150,105,.55); }
+.dtc-btn-ghost { background:transparent; color:var(--g-800) !important; border-color:var(--g-300); }
+.dtc-btn-ghost:hover { border-color:var(--g-600); }
+[data-theme="dark"] .dtc-btn-ghost { color:var(--g-300) !important; border-color:var(--dtc-border); }
 
-/* chain divider */
-.dtc-divider { display:flex; align-items:center; gap:0; margin:46px 0; }
+.dtc-divider { display:flex; align-items:center; gap:0; margin:40px 0; }
 .dtc-divider .seg { flex:1; height:2px; background:var(--dtc-border); }
-.dtc-divider .lk { font-size:18px; color:var(--dtc-orange); margin:0 -1px; }
+.dtc-divider .lk { font-size:18px; color:var(--g-500); margin:0 -1px; }
 
-/* section heading */
-.dtc-sec-head { text-align:center; max-width:640px; margin:0 auto 36px; }
+.dtc-sec-head { text-align:center; max-width:660px; margin:0 auto 34px; }
 .dtc-sec-head h2 { font-size:clamp(24px,3.2vw,34px); font-weight:850; letter-spacing:-.02em; color:var(--dtc-ink); }
 .dtc-sec-head p { color:var(--dtc-muted); font-size:17px; margin-top:10px; }
 
-/* toolchain pipeline (Element A) */
-.dtc-pipeline {
-  display:flex; align-items:flex-start; justify-content:space-between;
-  position:relative; gap:8px; flex-wrap:wrap;
-}
-.dtc-pipeline::before {
-  content:""; position:absolute; left:42px; right:42px; top:34px; height:3px;
-  background:repeating-linear-gradient(90deg, var(--dtc-blue-500) 0 10px, transparent 10px 18px);
-  opacity:.45; animation:dtcFlow 1.4s linear infinite;
-}
+.dtc-pipeline { display:flex; align-items:flex-start; justify-content:space-between; position:relative; gap:8px; flex-wrap:wrap; }
+.dtc-pipeline::before { content:""; position:absolute; left:42px; right:42px; top:34px; height:3px; background:repeating-linear-gradient(90deg, var(--g-500) 0 10px, transparent 10px 18px); opacity:.5; animation:dtcFlow 1.4s linear infinite; }
 @keyframes dtcFlow { to { background-position:18px 0; } }
 @media (prefers-reduced-motion: reduce) { .dtc-pipeline::before { animation:none; } }
-.dtc-link {
-  position:relative; z-index:1; display:flex; flex-direction:column;
-  align-items:center; gap:11px; flex:1 1 120px; min-width:96px;
-}
-.dtc-link .node {
-  width:68px; height:68px; border-radius:20px; background:var(--dtc-bg);
-  border:2px solid var(--dtc-border); display:grid; place-items:center;
-  font-size:28px; box-shadow:var(--dtc-shadow); transition:transform .2s, border-color .2s;
-}
-.dtc-link:hover .node { border-color:var(--dtc-blue-500); transform:translateY(-5px) rotate(-3deg); }
+.dtc-link { position:relative; z-index:1; display:flex; flex-direction:column; align-items:center; gap:11px; flex:1 1 120px; min-width:96px; }
+.dtc-link .node { width:68px; height:68px; border-radius:20px; background:var(--dtc-card); border:2px solid var(--dtc-border); display:grid; place-items:center; font-size:28px; box-shadow:var(--dtc-shadow); transition:transform .2s, border-color .2s; }
+.dtc-link:hover .node { border-color:var(--g-600); transform:translateY(-5px) rotate(-3deg); }
 .dtc-link .node.on { background:var(--dtc-grad); border-color:transparent; }
 .dtc-link b { font-size:14px; color:var(--dtc-ink); }
 .dtc-link span { font-family:var(--dtc-mono); font-size:11px; color:var(--dtc-muted); }
 
-/* feature grid */
 .dtc-features { display:grid; grid-template-columns:repeat(3,1fr); gap:20px; }
 @media (max-width:820px) { .dtc-features { grid-template-columns:1fr; } }
-.dtc-card {
-  background:var(--dtc-card); border:1px solid var(--dtc-border);
-  border-radius:var(--dtc-radius); padding:28px; box-shadow:var(--dtc-shadow);
-  transition:transform .2s, border-color .2s;
-}
-.dtc-card:hover { transform:translateY(-5px); border-color:var(--dtc-blue-500); }
-.dtc-card .ic {
-  width:50px; height:50px; border-radius:13px; display:grid; place-items:center;
-  font-size:23px; margin-bottom:16px; background:var(--dtc-teal-100);
-}
-[data-theme="dark"] .dtc-card .ic { background:rgba(95,208,192,.12); }
+.dtc-card { background:var(--dtc-card); border:1px solid var(--dtc-border); border-radius:var(--dtc-radius); padding:28px; box-shadow:var(--dtc-shadow); transition:transform .2s, border-color .2s; }
+.dtc-card:hover { transform:translateY(-5px); border-color:var(--g-600); }
+.dtc-card .ic { width:50px; height:50px; border-radius:13px; display:grid; place-items:center; font-size:23px; margin-bottom:16px; background:var(--g-100); }
+[data-theme="dark"] .dtc-card .ic { background:rgba(16,185,129,.14); }
 .dtc-card h3 { font-size:18px; letter-spacing:-.01em; margin:0 0 8px; color:var(--dtc-ink); }
 .dtc-card p { color:var(--dtc-muted); font-size:15px; margin:0; }
+
+/* =====================================================================
+   FULL DARK MODE — adapt legacy Bootstrap / Docsy components
+   ===================================================================== */
+[data-theme="dark"] .td-main,
+[data-theme="dark"] .td-content,
+[data-theme="dark"] main[role="main"] { background:transparent; color:var(--dtc-ink); }
+[data-theme="dark"] .td-content p,
+[data-theme="dark"] .td-content li,
+[data-theme="dark"] .td-content td,
+[data-theme="dark"] .td-content dt,
+[data-theme="dark"] .td-content dd,
+[data-theme="dark"] .td-content span:not(.arc42-num) { color:var(--dtc-ink); }
+
+/* Bootstrap cards (used on the landing page) */
+[data-theme="dark"] .card { background:var(--dtc-card) !important; border-color:var(--dtc-border) !important; color:var(--dtc-ink); }
+[data-theme="dark"] .card-header { background:var(--dtc-bg-soft) !important; border-color:var(--dtc-border) !important; color:var(--dtc-ink); }
+[data-theme="dark"] .card-body { color:var(--dtc-ink); }
+[data-theme="dark"] .card-body, [data-theme="dark"] .card-header h4 { color:var(--dtc-ink); }
+
+/* generic light surfaces */
+[data-theme="dark"] .bg-light { background:var(--dtc-bg-soft) !important; color:var(--dtc-ink); }
+[data-theme="dark"] .bg-light.jumbotron,
+[data-theme="dark"] div.bg-light.jumbotron { background:linear-gradient(135deg,#0c241b,#0a1a14) !important; border-color:var(--dtc-border); color:var(--dtc-ink); }
+
+/* sidebars / chrome */
+[data-theme="dark"] .td-sidebar,
+[data-theme="dark"] .td-sidebar__inner { background:transparent; }
+[data-theme="dark"] .td-breadcrumb a,
+[data-theme="dark"] .breadcrumb a { color:var(--g-300); }
+[data-theme="dark"] .td-toc a { color:var(--dtc-muted); }
+
+/* asciidoc literal / listing background already dark; ensure text */
+[data-theme="dark"] .td-content .literalblock pre { background:var(--dtc-code-bg); color:var(--dtc-code-ink); }
+
+/* outline buttons readable on dark */
+[data-theme="dark"] .btn-outline-primary { color:var(--g-300) !important; border-color:var(--g-500) !important; }
+[data-theme="dark"] .btn-outline-primary:hover { background:var(--g-600) !important; color:#fff !important; }
+
+/* horizontal rules / borders */
+[data-theme="dark"] hr { border-color:var(--dtc-border); }


### PR DESCRIPTION
## Problem

After the merge of #37, the microsite loaded **two competing v4 themes**:

| | `theme-v4.css` (green) | `doctoolchain-v4.css` (blue blueprint) |
|---|---|---|
| Loads | early | **last → wins** |
| Dark mode | none | **auto (`prefers-color-scheme`)** |

The blue overlay overrode the intended green theme, and its auto dark-mode flipped the whole site dark while Bootstrap/Docsy components stayed light → **invisible card text and dark-on-dark headings** (poor contrast). The modern blueprint landing also got dropped in the merge.

## Decision

Per maintainer: **green as the base** + make dark mode **fully functional**.

## Changes

- **Recolour the overlay blue → emerald**, so it *extends* `theme-v4.css` instead of fighting it (navbar, headings, hero, pipeline, arc42 numbers, code, admonitions, tables).
- **Full dark mode**: `[data-theme="dark"]` rules for Bootstrap cards, `.bg-light`/jumbotron, Docsy sidebar/toc/breadcrumb, asciidoc content, outline buttons and tables — nothing becomes unreadable.
- **Restore the modern landing**: green blueprint hero + animated toolchain pipeline on docToolchain's own landing page, preserving the existing v4 copy and ecosystem cards.

## Verification

Built with `./dtcw4 local generateSite` and screenshotted with Playwright in **light and dark** for both landing and docs pages. Card text, headings and code are readable in both schemes; light mode is cohesive emerald.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0132BYQh29Rn2PiFxSbbNpBe)_