### PR TITLE
fix(v4): drop obsolete jcenter redirects; auto-create config when missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,10 @@
 import java.util.zip.ZipFile
 
-// fix versions for #1200
 buildscript {
-    configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if (details.requested.group == 'org.ysb33r.gradle' && details.requested.name == 'grolifant' && details.requested.version == '0.12.1') {
-                details.useVersion '0.16.1'
-                details.because 'jcenter redirect'
-                System.out.println ">>>>>>>>> fix grolifant"
-            }
-        }
-    }
     dependencies {
         classpath libs.html.sanity.check
     }
 }
-// /fix versions for #1200
 
 /*
  * This build file is part of the docToolchain

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -12,25 +12,6 @@ buildscript {
             url mavenRepository
         }
     }
-    configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if (details.requested.group == 'org.ysb33r.gradle' && details.requested.name == 'grolifant' && details.requested.version in ['0.12', '0.12.1']) {
-                details.useVersion '0.16.1'
-                details.because 'jcenter redirect'
-                System.out.println ">>>>>>>>> fix grolifant"
-            }
-            if (details.requested.group == 'org.codehaus.groovy.modules.http-builder' && details.requested.name == 'http-builder' && details.requested.version == '0.7.2') {
-                details.useVersion '0.7.1'
-                details.because 'jcenter redirect'
-                System.out.println ">>>>>>>>> fix http-builder"
-            }
-            if (details.requested.group == 'com.burgstaller' && details.requested.name == 'okhttp-digest') {
-               //changing the name:
-                details.useTarget group: 'io.github.rburgst', name: details.requested.name, version: '1.21'
-                System.out.println ">>>>>>>>> fix okhttp-digest"
-            }
-        }
-    }
     dependencies {
         classpath (libs.asciidoctor)
         classpath (libs.asciidoctor.pdf)

--- a/scripts/lib/DtcConfig.groovy
+++ b/scripts/lib/DtcConfig.groovy
@@ -23,17 +23,91 @@ class DtcConfig {
     static DtcConfig load(String docDir, String mainConfigFile) {
         def configFile = new File(docDir, mainConfigFile)
         if (!configFile.exists()) {
-            System.err.println "Configuration file not found: ${configFile.canonicalPath}"
-            System.err.println ""
-            System.err.println "Create a 'docToolchainConfig.groovy' in your project root."
-            System.err.println "You can download a template with: ./dtcw downloadTemplate"
-            System.exit(1)
+            if (!createMissingConfig(configFile, mainConfigFile)) {
+                System.exit(1)
+            }
         }
         ConfigObject config = new ConfigSlurper().parse(configFile.toURI().toURL())
         config.put('docDir', configFile.parent)
         config.put('mainConfigFile', configFile.name)
         return new DtcConfig(config)
     }
+
+    // When the config is missing: in headless mode create it from the default
+    // template automatically; interactively, offer to create it. Returns true
+    // when a config now exists, false when the user declined.
+    private static boolean createMissingConfig(File configFile, String mainConfigFile) {
+        System.err.println "Configuration file not found: ${configFile.canonicalPath}"
+        boolean create
+        if (isHeadless()) {
+            create = true
+            System.err.println "Headless mode — creating a default '${mainConfigFile}'."
+        } else {
+            System.err.print "Create a default '${mainConfigFile}' now? [Y/n] "
+            System.err.flush()
+            def answer = readUserLine()?.trim()?.toLowerCase()
+            create = (answer in [null, '', 'y', 'yes'])
+        }
+        if (!create) {
+            System.err.println "No config created. Create a '${mainConfigFile}' in your project root,"
+            System.err.println "e.g. with: ./dtcw4 downloadTemplate"
+            return false
+        }
+        def template = defaultConfigTemplate()
+        if (template?.exists()) {
+            configFile.bytes = template.bytes
+            System.err.println "Created '${configFile.canonicalPath}' from the default template."
+        } else {
+            configFile.text = MINIMAL_CONFIG
+            System.err.println "Created a minimal '${configFile.canonicalPath}'."
+        }
+        System.err.println "Review it and set 'inputFiles' to your documents."
+        return true
+    }
+
+    private static boolean isHeadless() {
+        def v = System.getProperty('DTC_HEADLESS', System.getenv('DTC_HEADLESS') ?: 'false')
+        return v == 'true'
+    }
+
+    private static String readUserLine() {
+        def console = System.console()
+        if (console != null) {
+            return console.readLine()
+        }
+        try {
+            return new BufferedReader(new InputStreamReader(System.in)).readLine()
+        } catch (ignored) {
+            return null
+        }
+    }
+
+    // The canonical default config docToolchain ships, located relative to this
+    // script: dtcHome/scripts/lib/DtcConfig.groovy -> dtcHome/template_config.
+    private static File defaultConfigTemplate() {
+        try {
+            def src = DtcConfig.protectionDomain?.codeSource?.location
+            if (src) {
+                def dtcHome = new File(src.toURI()).parentFile?.parentFile?.parentFile
+                def t = new File(dtcHome, 'template_config/Config.groovy')
+                if (t.exists()) {
+                    return t
+                }
+            }
+        } catch (ignored) { }
+        return null
+    }
+
+    private static final String MINIMAL_CONFIG = '''\
+// Minimal docToolchain configuration.
+// See template_config/Config.groovy in the docToolchain repo for all options.
+outputPath = 'build'
+inputPath  = 'src/docs'
+inputFiles = [
+    // [file: 'manual.adoc', formats: ['html', 'pdf']],
+]
+imageDirs  = []
+'''
 
     /**
      * Get a single config property by path (e.g. 'confluence.api').


### PR DESCRIPTION
Addresses two of the v4 rough edges spotted in a fresh-Codespace run. Implemented entirely on the v4 side (`build.gradle`, `scripts/`), **`dtcw` untouched** as requested.

## A) Remove obsolete jcenter redirects

The build printed `>>>>>>>>> fix okhttp-digest` (and siblings). These `resolutionStrategy` redirects (`fix grolifant`, `fix http-builder`, `fix okhttp-digest`) were jcenter-era workarounds. Verified: `packageLibs` builds cleanly **without** them — 178 JARs, no resolution errors, no `fix …` noise. Removed all three from `build.gradle` and `scripts/AsciiDocBasics.gradle` (build-time only, not in the v4 runtime).

## C) Auto-create the config when it's missing

Previously `DtcConfig` hard-exited with "Create a `docToolchainConfig.groovy` yourself". Now:

- **headless** (`DTC_HEADLESS=true`): creates a default from `template_config/Config.groovy` automatically and continues;
- **interactive**: offers to create it (`Create a default 'docToolchainConfig.groovy' now? [Y/n]`);
- falls back to a minimal inline config if the template can't be located.

Verified: headless auto-create, interactive `y` (creates) and `n` (declines with a `downloadTemplate` hint).

## Not included — B) the environment listing

```
Available docToolchain environments: local sdk docker
Environments with docToolchain [4.0.0]: local docker   ← claims docker has docToolchain
```

This is v3 logic (`get_dtc_installations`: "having docker installed means docToolchain is available") and lives entirely in the shared **`dtcw`**, which `dtcw4` delegates to. Per the request to leave `dtcw` untouched, it is **out of scope here** — it needs a `dtcw` change (v4-aware environment detection) to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0132BYQh29Rn2PiFxSbbNpBe)_