### PR TITLE
fix(dtcw): don't claim the docker environment has docToolchain on v4

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -258,8 +258,10 @@ get_dtc_installations() {
         installations+=" sdk"
     fi
 
-    if [[ "${envs}" =~ docker ]]; then
-        # Having docker installed means docToolchain is available
+    if [[ "${envs}" =~ docker ]] && ! is_v4_installation; then
+        # v3: the docToolchain image is published on Docker Hub, so having
+        # docker installed means docToolchain is available there. v4 does not
+        # have a published image yet, so don't claim it for v4.
         installations+=" docker"
     fi
     [ -z "${installations}" ] && installations=" none"

--- a/test/local_environment.bats
+++ b/test/local_environment.bats
@@ -92,6 +92,8 @@ teardown() {
     PATH="${minimal_system}" run -0 ./dtcw tasks --group doctoolchain
 
     assert_line "Available docToolchain environments: local docker"
-    assert_line "Environments with docToolchain [${DTC_VERSION}]: local docker"
+    # v4 has no published docker image yet, so docker is not claimed as an
+    # environment that already has docToolchain (only 'local' here).
+    assert_line "Environments with docToolchain [${DTC_VERSION}]: local"
     assert_line "Using environment: local"
 }


### PR DESCRIPTION
Fixes point **B** from the fresh-Codespace review — now that we can touch the v4 `dtcw` (it only gates on `! is_v4_installation`, so the v3 path is unchanged).

## Problem

A fresh v4 install on a host that has the docker CLI reported:

```
Available docToolchain environments: local sdk docker
Environments with docToolchain [4.0.0]: local docker   ← misleading
```

`get_dtc_installations` added `docker` to the "already has docToolchain" list whenever the docker CLI was present — comment: *"Having docker installed means docToolchain is available"*. That's a **v3 assumption** (the v3 image is on Docker Hub). v4 has no published image yet, so nothing docker-related was actually set up.

## Fix

Gate the docker claim on `! is_v4_installation`: v3 keeps the old behaviour, v4 reports only what's real:

```
Environments with docToolchain [4.0.0]: local
```

Also updates the non-skipped `installing docker has no side effect` bats spec (it encoded the v3 expectation against a v4 `DTC_VERSION`) to expect `local`. Full bats suite green locally apart from the pre-existing `DTC_VERSION=latest … git clone` cases, which are environment noise here and pass in CI.

## Deliberately not changed

The `Available docToolchain environments: local sdk docker` line reflects which tooling is present, and also feeds environment selection. Whether v4 should advertise `sdk`/`docker` at all (docker image pending; SDKMAN still ships v3) is a separate product decision — happy to follow up if you want it restricted to `local` for v4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0132BYQh29Rn2PiFxSbbNpBe)_