### PR TITLE
feat(v4): actionable hint when a diagram tool (dot/mmdc) is missing

### DIFF
--- a/scripts/generateHTML.groovy
+++ b/scripts/generateHTML.groovy
@@ -45,6 +45,9 @@ if (!htmlFiles) {
 def imageDirs = config.imageDirs ?: ['images']
 def asciidoctor = Asciidoctor.Factory.create()
 asciidoctor.requireLibrary('asciidoctor-diagram')
+def diagramHints = new GroovyClassLoader(this.class.classLoader)
+    .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy')).newInstance()
+diagramHints.register(asciidoctor)
 println "AsciidoctorJ ${Asciidoctor.class.package.implementationVersion ?: '2.5.x'} ready (with diagram support)"
 
 def failed = false
@@ -90,6 +93,7 @@ htmlFiles.each { entry ->
     }
 }
 
+diagramHints.printHints()
 asciidoctor.close()
 println ""
 if (failed) {

--- a/scripts/generatePDF.groovy
+++ b/scripts/generatePDF.groovy
@@ -48,6 +48,9 @@ def asciidoctor = Asciidoctor.Factory.create()
 // Register PDF converter by requiring the gem
 asciidoctor.requireLibrary('asciidoctor-pdf')
 asciidoctor.requireLibrary('asciidoctor-diagram')
+def diagramHints = new GroovyClassLoader(this.class.classLoader)
+    .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy')).newInstance()
+diagramHints.register(asciidoctor)
 println "AsciidoctorJ PDF ready (with diagram support)"
 
 def failed = false
@@ -103,6 +106,7 @@ pdfFiles.each { entry ->
     }
 }
 
+diagramHints.printHints()
 asciidoctor.close()
 println ""
 if (failed) {

--- a/scripts/lib/DiagramToolHints.groovy
+++ b/scripts/lib/DiagramToolHints.groovy
@@ -1,0 +1,86 @@
+// v4: Turn cryptic asciidoctor-diagram "Could not find the 'xxx' executable"
+// failures into an actionable hint — how to install the tool, or how to render
+// diagrams remotely via a Kroki server (no local tools needed).
+//
+// AsciidoctorJ delivers diagram failures (e.g.
+//   "Could not find the 'dot' executable in PATH; ...")
+// to registered LogHandlers. The raw message still goes to stderr — AsciidoctorJ
+// does not let us selectively suppress a single record — so we collect the
+// missing tools and print one consolidated hint block at the end.
+//
+// Usage:
+//   def Hints = new GroovyClassLoader(this.class.classLoader)
+//       .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy'))
+//   def hints = Hints.newInstance()
+//   hints.register(asciidoctor)   // right after Asciidoctor.Factory.create()
+//   ... convert ...
+//   hints.printHints()            // before asciidoctor.close()
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.log.LogHandler
+import org.asciidoctor.log.LogRecord
+
+class DiagramToolHints {
+
+    // executable name -> description + install commands
+    private static final Map TOOLS = [
+        dot  : [name: 'Graphviz',    purpose: 'GraphViz (and some PlantUML) diagrams',
+                install: ['Linux (Debian/Ubuntu): sudo apt-get install -y graphviz',
+                          'macOS:                 brew install graphviz']],
+        mmdc : [name: 'Mermaid CLI', purpose: 'Mermaid diagrams',
+                install: ['npm install -g @mermaid-js/mermaid-cli']],
+        ditaa: [name: 'ditaa',       purpose: 'ditaa diagrams',
+                install: ['Linux (Debian/Ubuntu): sudo apt-get install -y ditaa']],
+    ]
+
+    private final Set<String> missing = new LinkedHashSet<>()
+
+    /** Register a log handler that records missing diagram executables. */
+    void register(Asciidoctor asciidoctor) {
+        asciidoctor.registerLogHandler({ LogRecord record ->
+            def msg = record?.message
+            if (msg) {
+                def m = (msg =~ /Could not find the '([\w.+-]+)' executable/)
+                if (m) {
+                    missing << m[0][1]
+                }
+            }
+        } as LogHandler)
+    }
+
+    boolean hasMissing() { !missing.isEmpty() }
+
+    /** Print one consolidated, actionable hint for every missing tool. */
+    void printHints() {
+        if (missing.isEmpty()) {
+            return
+        }
+        def out = System.err
+        def line = '-' * 72
+        out.println ""
+        out.println line
+        out.println "Some diagrams were not rendered - a local diagram tool is missing:"
+        out.println ""
+        missing.each { tool ->
+            def info = TOOLS[tool]
+            if (info) {
+                out.println "  * '${tool}' (${info.name}) - needed for ${info.purpose}"
+                info.install.each { out.println "        ${it}" }
+            } else {
+                out.println "  * '${tool}' executable not found in PATH"
+            }
+        }
+        out.println ""
+        out.println "  Or render diagrams remotely via a Kroki server (no local tools"
+        out.println "  needed) by adding to docToolchainConfig.groovy:"
+        out.println ""
+        out.println "      asciidoctorAttributes = ["
+        out.println "          'diagram-server-url' : 'https://kroki.io/',"
+        out.println "          'diagram-server-type': 'kroki_io',"
+        out.println "      ]"
+        out.println ""
+        out.println "  See the 'Kroki Configuration Guide' in the docToolchain tutorial"
+        out.println "  (https://doctoolchain.org) or run your own server: https://kroki.io"
+        out.println line
+    }
+}

--- a/scripts/lib/MicrositeBaker.groovy
+++ b/scripts/lib/MicrositeBaker.groovy
@@ -106,6 +106,8 @@ class MicrositeBaker {
 
         asciidoctor = Asciidoctor.Factory.create()
         asciidoctor.requireLibrary('asciidoctor-diagram')
+        def diagramHints = loadDiagramHints()
+        diagramHints?.register(asciidoctor)
 
         crawl()
         buildModelLists()
@@ -113,8 +115,20 @@ class MicrositeBaker {
         renderSpecialPages()
         copyAssets()
 
+        diagramHints?.printHints()
         asciidoctor.close()
         println "MicrositeBaker: rendered ${allContent.size()} content pages."
+    }
+
+    // Load the DiagramToolHints helper from the same scripts/lib directory.
+    private Object loadDiagramHints() {
+        try {
+            def libDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+            return new GroovyClassLoader(getClass().classLoader)
+                    .parseClass(new File(libDir, 'DiagramToolHints.groovy')).newInstance()
+        } catch (Throwable ignored) {
+            return null
+        }
     }
 
     // --- config model (site_*, sourceFolder, contentFolder, jbake props) ---


### PR DESCRIPTION
When a diagram tool isn't installed, asciidoctor-diagram only emits a cryptic line like:

```
SEVERE: Failed to generate image: Could not find the 'dot' executable in PATH;
add it to the PATH or specify its location using the 'graphvizdot' document attribute
```

This adds an **actionable hint** telling the user how to fix it — install the tool, or render remotely via Kroki.

## What

`scripts/lib/DiagramToolHints.groovy` registers an AsciidoctorJ log handler that detects `Could not find the '<tool>' executable`, collects the missing executables, and prints one consolidated block after rendering, e.g.:

```
------------------------------------------------------------------------
Some diagrams were not rendered - a local diagram tool is missing:

  * 'dot' (Graphviz) - needed for GraphViz (and some PlantUML) diagrams
        Linux (Debian/Ubuntu): sudo apt-get install -y graphviz
        macOS:                 brew install graphviz
  * 'mmdc' (Mermaid CLI) - needed for Mermaid diagrams
        npm install -g @mermaid-js/mermaid-cli

  Or render diagrams remotely via a Kroki server (no local tools
  needed) by adding to docToolchainConfig.groovy:

      asciidoctorAttributes = [
          'diagram-server-url' : 'https://kroki.io/',
          'diagram-server-type': 'kroki_io',
      ]

  See the 'Kroki Configuration Guide' in the docToolchain tutorial ...
------------------------------------------------------------------------
```

Wired into **generateHTML**, **generatePDF** and **generateSite** (MicrositeBaker). The hint only lists tools that actually failed; ASCII-only for terminal portability. Known tools: `dot`/graphviz, `mmdc`/mermaid, `ditaa` (unknown tools fall back to a generic line).

## Note

AsciidoctorJ delivers the failure to registered log handlers **in addition to** its own stderr output — it doesn't let us selectively suppress a single record — so the raw `Could not find …` line still appears above the hint. The hint is additive guidance, which is the missing piece.

Verified end-to-end on JDK 25 via generateHTML and generateSite (Mermaid block, `mmdc` absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0132BYQh29Rn2PiFxSbbNpBe)_